### PR TITLE
add compability for Edge

### DIFF
--- a/src/InputTag.vue
+++ b/src/InputTag.vue
@@ -47,7 +47,7 @@
       },
 
       addNew (tag) {
-        if (tag && !this.tags.includes(tag) && this.validateIfNeeded(tag)) {
+        if (tag && this.tags.indexOf(tag) === -1 && this.validateIfNeeded(tag)) {
           this.tags.push(tag)
           this.tagChange()
         }


### PR DESCRIPTION
Edge does not support Array.prototype.includes() . Adding tag ends with error: _Object doesn't support property or method 'includes'_

