### PR TITLE
Immutable tags

### DIFF
--- a/docs/App.vue
+++ b/docs/App.vue
@@ -87,7 +87,7 @@
 
         input-tag(
           :on-change='newTag',
-          :tags='tags',
+          :tags.sync='tags',
           :placeholder='placeholder',
           :read-only='readOnly',
           :validate='validate'

--- a/src/InputTag.vue
+++ b/src/InputTag.vue
@@ -93,12 +93,12 @@
 
 <template>
 
-  <div @click="focusNewTag()" v-bind:class="{'read-only': readOnly}" class="vue-input-tag-wrapper">
-    <span v-for="(tag, index) in innerTags" v-bind:key="index" class="input-tag">
+  <div @click="focusNewTag()" :class="{'read-only': readOnly}" class="vue-input-tag-wrapper">
+    <span v-for="(tag, index) in innerTags" :key="index" class="input-tag">
       <span>{{ tag }}</span>
       <a v-if="!readOnly" @click.prevent.stop="remove(index)" class="remove"></a>
     </span>
-    <input v-if="!readOnly" v-bind:placeholder="placeholder" type="text" v-model="newTag" v-on:keydown.delete.stop="removeLastTag()" v-on:keydown.enter.188.prevent.stop="addNew(newTag)" class="new-tag"/>
+    <input v-if="!readOnly" :placeholder="placeholder" type="text" v-model="newTag" v-on:keydown.delete.stop="removeLastTag()" v-on:keydown.enter.188.prevent.stop="addNew(newTag)" class="new-tag"/>
   </div>
 
 </template>

--- a/src/InputTag.vue
+++ b/src/InputTag.vue
@@ -36,7 +36,14 @@
 
     data () {
       return {
-        newTag: ''
+        newTag: '',
+        innerTags: this.tags
+      }
+    },
+
+    watch: {
+      tags () {
+        this.innerTags = this.tags
       }
     },
 
@@ -47,8 +54,8 @@
       },
 
       addNew (tag) {
-        if (tag && this.tags.indexOf(tag) === -1 && this.validateIfNeeded(tag)) {
-          this.tags.push(tag)
+        if (tag && this.innerTags.indexOf(tag) === -1 && this.validateIfNeeded(tag)) {
+          this.innerTags.push(tag)
           this.tagChange()
         }
         this.newTag = ''
@@ -64,20 +71,20 @@
       },
 
       remove (index) {
-        this.tags.splice(index, 1)
+        this.innerTags.splice(index, 1)
         this.tagChange()
       },
 
       removeLastTag () {
         if (this.newTag) { return }
-        this.tags.pop()
+        this.innerTags.pop()
         this.tagChange()
       },
 
       tagChange () {
         if (this.onChange) {
           // avoid passing the observer
-          this.onChange(JSON.parse(JSON.stringify(this.tags)))
+          this.onChange(JSON.parse(JSON.stringify(this.innerTags)))
         }
       }
     }
@@ -87,7 +94,7 @@
 <template>
 
   <div @click="focusNewTag()" v-bind:class="{'read-only': readOnly}" class="vue-input-tag-wrapper">
-    <span v-for="(tag, index) in tags" v-bind:key="index" class="input-tag">
+    <span v-for="(tag, index) in innerTags" v-bind:key="index" class="input-tag">
       <span>{{ tag }}</span>
       <a v-if="!readOnly" @click.prevent.stop="remove(index)" class="remove"></a>
     </span>

--- a/src/InputTag.vue
+++ b/src/InputTag.vue
@@ -37,13 +37,13 @@
     data () {
       return {
         newTag: '',
-        innerTags: this.tags
+        innerTags: [...this.tags]
       }
     },
 
     watch: {
       tags () {
-        this.innerTags = this.tags
+        this.innerTags = [...this.tags]
       }
     },
 
@@ -86,6 +86,8 @@
           // avoid passing the observer
           this.onChange(JSON.parse(JSON.stringify(this.innerTags)))
         }
+
+        this.$emit('update:tags', this.innerTags)
       }
     }
   }


### PR DESCRIPTION
This PR's attempts to be compliance with **[One Way Data Flow](https://vuejs.org/v2/guide/components.html#One-Way-Data-Flow)**  preventing to mutate `tags` property. The component has now an inner data property (`innerTags`)  which watches the value of `tags`. Any time a new tag is added or removed, the component emits an event `update:tags` and sends to parent component the new tags list.

There is no need to listen the event manually in parent component because we can use `sync`  modifier which provides syntax sugar to automatically update prop based on event the `update` event.

`sync` modifier [docs](https://vuejs.org/v2/guide/components.html#sync-Modifier)