### PR TITLE
Improve styling for long tag names

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import InputTag from 'vue-input-tag'
 ## Usage
 
 ``` html
-<input-tag :on-change="callbackMethod" :tags="tagsArray"></input-tag>
+<input-tag :tags.sync="tagsArray"></input-tag>
 ```
 
 ## Props

--- a/src/InputTag.vue
+++ b/src/InputTag.vue
@@ -70,13 +70,13 @@ export default {
     },
 
     addNew (e) {
-      // Do nothing if the current key code is 
+      // Do nothing if the current key code is
       // not within those defined within the addTagOnKeys prop array.
       if ((e && this.addTagOnKeys.indexOf(e.keyCode) === -1) || this.isLimit) {
         return
       }
 
-      // We prevent default & stop propagation for all 
+      // We prevent default & stop propagation for all
       // keys except tabs (used to move between controls)
       if (e && e.keyCode !== 9) {
         e.stopPropagation()
@@ -150,6 +150,8 @@ export default {
     cursor: text;
     text-align: left;
     -webkit-appearance: textfield;
+    display: flex;
+    flex-wrap: wrap;
   }
 
   .vue-input-tag-wrapper .input-tag {
@@ -190,6 +192,7 @@ export default {
     outline: none;
     padding: 4px;
     padding-left: 0;
+    flex-grow: 1;
   }
 
   .vue-input-tag-wrapper.read-only {


### PR DESCRIPTION
Currently, the input for entering tag names doesn't fill all available space, which leads to strange behavior when typing long tag names.