### PR TITLE
Add option to add tag on blur

### DIFF
--- a/src/InputTag.vue
+++ b/src/InputTag.vue
@@ -39,6 +39,10 @@ export default {
         ]
       }
     },
+    addTagOnBlur: {
+      type: Boolean,
+      default: false
+    },
     limit: {
       default: -1
     }
@@ -72,7 +76,8 @@ export default {
     addNew (e) {
       // Do nothing if the current key code is
       // not within those defined within the addTagOnKeys prop array.
-      if ((e && this.addTagOnKeys.indexOf(e.keyCode) === -1) || this.isLimit) {
+      if ((e && this.addTagOnKeys.indexOf(e.keyCode) === -1 &&
+              (e.type !== 'blur' || !this.addTagOnBlur)) || this.isLimit) {
         return
       }
 
@@ -135,6 +140,7 @@ export default {
       v-model                  = "newTag"
       v-on:keydown.delete.stop = "removeLastTag"
       v-on:keydown             = "addNew"
+      v-on:blur                = "addNew"
       class                    = "new-tag"
     />
   </div>


### PR DESCRIPTION
Hello! Thanks for this great library. I noticed that the input was ignoring the last tag added if the user simply left the input without hitting enter, etc. Obviously most users would notice that the tag doesn't look right, but some users assume that their typed text is also being included.

I added a prop called `addTagOnBlur` which, as the name suggests, adds the tag when the user moves on. I set to false by default as to not break any current implementations, though I don't think it'd be too harmful to enable by default.

Thanks again for the library!