### PR TITLE
Add activity CSS class to component when input is focused

### DIFF
--- a/src/InputTag.vue
+++ b/src/InputTag.vue
@@ -1,5 +1,5 @@
 <script>
-/*eslint-disable*/
+/* eslint-disable */
  const validators = {
   email: new RegExp(/^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/),
   url: new RegExp(/^(https?|ftp|rmtp|mms):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(:(\d+))?\/?/i),
@@ -7,7 +7,7 @@
   digits: new RegExp(/^[\d() \.\:\-\+#]+$/),
   isodate: new RegExp(/^\d{4}[\/\-](0?[1-9]|1[012])[\/\-](0?[1-9]|[12][0-9]|3[01])$/)
 }
-/*eslint-enable*/
+/* eslint-enable */
 
 export default {
   name: 'InputTag',
@@ -51,7 +51,8 @@ export default {
   data () {
     return {
       newTag: '',
-      innerTags: [...this.tags]
+      innerTags: [...this.tags],
+      isInputActive: false
     }
   },
 
@@ -73,6 +74,15 @@ export default {
       this.$el.querySelector('.new-tag').focus()
     },
 
+    handleInputFocus () {
+      this.isInputActive = true
+    },
+
+    handleInputBlur (e) {
+      this.isInputActive = false
+      this.addNew(e)
+    },
+
     addNew (e) {
       // Do nothing if the current key code is
       // not within those defined within the addTagOnKeys prop array.
@@ -80,7 +90,6 @@ export default {
               (e.type !== 'blur' || !this.addTagOnBlur)) || this.isLimit) {
         return
       }
-
       if (e) {
         e.stopPropagation()
         e.preventDefault()
@@ -127,7 +136,14 @@ export default {
 </script>
 
 <template>
-  <div @click="focusNewTag()" :class="{'read-only': readOnly}" class="vue-input-tag-wrapper">
+  <div
+    @click="focusNewTag()"
+    :class="{
+      'read-only': readOnly,
+      'vue-input-tag-wrapper--active': isInputActive,
+    }"
+    class="vue-input-tag-wrapper"
+  >
     <span v-for="(tag, index) in innerTags" :key="index" class="input-tag">
       <span>{{ tag }}</span>
       <a v-if="!readOnly" @click.prevent.stop="remove(index)" class="remove"></a>
@@ -140,7 +156,8 @@ export default {
       v-model                  = "newTag"
       v-on:keydown.delete.stop = "removeLastTag"
       v-on:keydown             = "addNew"
-      v-on:blur                = "addNew"
+      v-on:blur                = "handleInputBlur"
+      v-on:focus               = "handleInputFocus"
       class                    = "new-tag"
     />
   </div>

--- a/test/InputTag.spec.js
+++ b/test/InputTag.spec.js
@@ -250,4 +250,22 @@ describe('InputTag.vue', () => {
       expect(InputTagISODateOnly.innerTags.length).toEqual(1)
     })
   })
+
+  describe('CSS classes depending of input state', () => {
+    it('should add activity class when input is focused', () => {
+      InputTagComponent.$refs.inputtag.focus()
+      return Vue.nextTick()
+        .then(() => {
+          expect(InputTagComponent.$el.classList.contains('vue-input-tag-wrapper--active')).toBe(true)
+        })
+    })
+
+    it('should remove activity class when input is blurred', () => {
+      InputTagComponent.$refs.inputtag.blur()
+      return Vue.nextTick()
+        .then(() => {
+          expect(InputTagComponent.$el.classList.contains('vue-input-tag-wrapper--active')).toBe(false)
+        })
+    })
+  })
 })


### PR DESCRIPTION
Setting `isInputActive` flag is put into the new `handleInputFocus` method instead of `focusNewTag` because input tabbing should be handled.