### PR TITLE
Validate with function, allow duplicattes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 npm-debug.log
 coverage
 .log
+.idea/**

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Vue.component('input-tag', InputTag);
 ```html
 <input-tag :tags.sync="tagsArray"></input-tag>
 ```
+or to only allow adding 'green', 'yellow' or 'red' tags:
+```html
+<input-tag :tags.sync="tagsArray" :validate="tag => ['green','yellow','red'].includes(tag)"></input-tag>
+```
 
 ## Props
 | Name | Type | Default | Description |
@@ -54,8 +58,9 @@ Vue.component('input-tag', InputTag);
 | read-only | Boolean | false | Set input to readonly |
 | addTagOnBlur | Boolean | false | Add tag on input blur |
 | limit | String or Number | -1 (none) | Set a limit for the amount of tags |
-| validate | String/Object | "" | Apply certain validator for user input. Choose from `email`, `url`, `text`, `digits` or `isodate` or pass a `RegExp` object for custom validation |
+| validate | String or Function or Object | "" | Apply certain validator for user input. Choose from `email`, `url`, `text`, `digits` or `isodate`. Or pass a `function` or a `RegExp` object for custom validation |
 | addTagOnKeys | Array | [ 13 (return), 188 (comma), 9 (tab) ] | Keys that are going to add the new tag
+| allowDuplicates | Boolean | false | Allow duplicate tags
 
 **This project was built with [generator-vue-component](https://github.com/ianaya89/generator-vue-component) ❤️**
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules",
     "build:docs": "cross-env NODE_ENV=docs webpack --progress --hide-modules",
     "lint": "eslint --ext .js,.vue src test/unit/specs",
-    "lint:fix": "eslint --fix .",
+    "lint:fix": "eslint --fix --ext .js,.vue src test/unit/specs",
     "prepublish": "npm run build",
     "test": "jest --coverage"
   },

--- a/src/InputTag.vue
+++ b/src/InputTag.vue
@@ -1,8 +1,12 @@
 <script>
 /* eslint-disable */
- const validators = {
-  email: new RegExp(/^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/),
-  url: new RegExp(/^(https?|ftp|rmtp|mms):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(:(\d+))?\/?/i),
+const validators = {
+  email: new RegExp(
+    /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+  ),
+  url: new RegExp(
+    /^(https?|ftp|rmtp|mms):\/\/(([A-Z0-9][A-Z0-9_-]*)(\.[A-Z0-9][A-Z0-9_-]*)+)(:(\d+))?\/?/i
+  ),
   text: new RegExp(/^[a-zA-Z]+$/),
   digits: new RegExp(/^[\d() \.\:\-\+#]+$/),
   isodate: new RegExp(/^\d{4}[\/\-](0?[1-9]|1[012])[\/\-](0?[1-9]|[12][0-9]|3[01])$/)
@@ -26,7 +30,7 @@ export default {
       default: false
     },
     validate: {
-      type: String | Object,
+      type: String | Function | Object,
       default: ''
     },
     addTagOnKeys: {
@@ -44,7 +48,12 @@ export default {
       default: false
     },
     limit: {
+      type: Number,
       default: -1
+    },
+    allowDuplicates: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -70,7 +79,9 @@ export default {
 
   methods: {
     focusNewTag () {
-      if (this.readOnly || !this.$el.querySelector('.new-tag')) { return }
+      if (this.readOnly || !this.$el.querySelector('.new-tag')) {
+        return
+      }
       this.$el.querySelector('.new-tag').focus()
     },
 
@@ -86,8 +97,12 @@ export default {
     addNew (e) {
       // Do nothing if the current key code is
       // not within those defined within the addTagOnKeys prop array.
-      if ((e && this.addTagOnKeys.indexOf(e.keyCode) === -1 &&
-              (e.type !== 'blur' || !this.addTagOnBlur)) || this.isLimit) {
+      if (
+        (e &&
+          this.addTagOnKeys.indexOf(e.keyCode) === -1 &&
+          (e.type !== 'blur' || !this.addTagOnBlur)) ||
+        this.isLimit
+      ) {
         return
       }
       if (e) {
@@ -97,7 +112,7 @@ export default {
 
       if (
         this.newTag &&
-        this.innerTags.indexOf(this.newTag) === -1 &&
+        (this.allowDuplicates || this.innerTags.indexOf(this.newTag) === -1) &&
         this.validateIfNeeded(this.newTag)
       ) {
         this.innerTags.push(this.newTag)
@@ -109,9 +124,20 @@ export default {
     validateIfNeeded (tagValue) {
       if (this.validate === '' || this.validate === undefined) {
         return true
-      } else if (typeof (this.validate) === 'string' && Object.keys(validators).indexOf(this.validate) > -1) {
+      } else if (
+        typeof this.validate === 'string' &&
+        Object.keys(validators).indexOf(this.validate) > -1
+      ) {
         return validators[this.validate].test(tagValue)
-      } else if (typeof (this.validate) === 'object' && this.validate.test !== undefined) {
+      } else if (
+        typeof this.validate === 'function' &&
+        this.validate.call !== undefined
+      ) {
+        return this.validate(tagValue)
+      } else if (
+        typeof this.validate === 'object' &&
+        this.validate.test !== undefined
+      ) {
         return this.validate.test(tagValue)
       }
       return true
@@ -123,7 +149,9 @@ export default {
     },
 
     removeLastTag () {
-      if (this.newTag) { return }
+      if (this.newTag) {
+        return
+      }
       this.innerTags.pop()
       this.tagChange()
     },
@@ -164,61 +192,61 @@ export default {
 </template>
 
 <style>
-  .vue-input-tag-wrapper {
-    background-color: #fff;
-    border: 1px solid #ccc;
-    overflow: hidden;
-    padding-left: 4px;
-    padding-top: 4px;
-    cursor: text;
-    text-align: left;
-    -webkit-appearance: textfield;
-    display: flex;
-    flex-wrap: wrap;
-  }
+.vue-input-tag-wrapper {
+  background-color: #fff;
+  border: 1px solid #ccc;
+  overflow: hidden;
+  padding-left: 4px;
+  padding-top: 4px;
+  cursor: text;
+  text-align: left;
+  -webkit-appearance: textfield;
+  display: flex;
+  flex-wrap: wrap;
+}
 
-  .vue-input-tag-wrapper .input-tag {
-    background-color: #cde69c;
-    border-radius: 2px;
-    border: 1px solid #a5d24a;
-    color: #638421;
-    display: inline-block;
-    font-size: 13px;
-    font-weight: 400;
-    margin-bottom: 4px;
-    margin-right: 4px;
-    padding: 3px;
-  }
+.vue-input-tag-wrapper .input-tag {
+  background-color: #cde69c;
+  border-radius: 2px;
+  border: 1px solid #a5d24a;
+  color: #638421;
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 400;
+  margin-bottom: 4px;
+  margin-right: 4px;
+  padding: 3px;
+}
 
-  .vue-input-tag-wrapper .input-tag .remove {
-    cursor: pointer;
-    font-weight: bold;
-    color: #638421;
-  }
+.vue-input-tag-wrapper .input-tag .remove {
+  cursor: pointer;
+  font-weight: bold;
+  color: #638421;
+}
 
-  .vue-input-tag-wrapper .input-tag .remove:hover {
-    text-decoration: none;
-  }
+.vue-input-tag-wrapper .input-tag .remove:hover {
+  text-decoration: none;
+}
 
-  .vue-input-tag-wrapper .input-tag .remove::before {
-    content: " x";
-  }
+.vue-input-tag-wrapper .input-tag .remove::before {
+  content: " x";
+}
 
-  .vue-input-tag-wrapper .new-tag {
-    background: transparent;
-    border: 0;
-    color: #777;
-    font-size: 13px;
-    font-weight: 400;
-    margin-bottom: 6px;
-    margin-top: 1px;
-    outline: none;
-    padding: 4px;
-    padding-left: 0;
-    flex-grow: 1;
-  }
+.vue-input-tag-wrapper .new-tag {
+  background: transparent;
+  border: 0;
+  color: #777;
+  font-size: 13px;
+  font-weight: 400;
+  margin-bottom: 6px;
+  margin-top: 1px;
+  outline: none;
+  padding: 4px;
+  padding-left: 0;
+  flex-grow: 1;
+}
 
-  .vue-input-tag-wrapper.read-only {
-    cursor: default;
-  }
+.vue-input-tag-wrapper.read-only {
+  cursor: default;
+}
 </style>

--- a/test/InputTag.spec.js
+++ b/test/InputTag.spec.js
@@ -12,14 +12,18 @@ describe('InputTag.vue', () => {
 
   beforeEach((cb) => {
     InputTagComponent = new ClonedComponent({
-      data () { return { innerTags: [] } }
+      data () {
+        return { innerTags: [] }
+      }
     }).$mount()
     cb()
   })
 
   it('should have a new tag input without placeholder', () => {
     renderer.renderToString(InputTagComponent, (err, str) => {
-      if (err) { throw err }
+      if (err) {
+        throw err
+      }
 
       const dom = new jsdom.JSDOM(str)
       const input = dom.window.document.querySelector('input.new-tag')
@@ -80,13 +84,17 @@ describe('InputTag.vue', () => {
 
   describe('read-only="true"', () => {
     const InputTagComponentReadOnly = new ClonedComponent({
-      data () { return { innerTags: [] } },
+      data () {
+        return { innerTags: [] }
+      },
       propsData: { readOnly: true }
     }).$mount()
 
     it('should have a read-only CSS class and shouldn\'t have a remove tag button', () => {
       renderer.renderToString(InputTagComponentReadOnly, (err, str) => {
-        if (err) { throw err }
+        if (err) {
+          throw err
+        }
 
         const dom = new jsdom.JSDOM(str)
         const input = dom.window.document.querySelector('.read-only')
@@ -98,7 +106,9 @@ describe('InputTag.vue', () => {
 
     it('shouldn\'t have a new tag input', () => {
       renderer.renderToString(InputTagComponentReadOnly, (err, str) => {
-        if (err) { throw err }
+        if (err) {
+          throw err
+        }
 
         const dom = new jsdom.JSDOM(str)
         const input = dom.window.document.querySelector('input.new-tag')
@@ -110,7 +120,9 @@ describe('InputTag.vue', () => {
 
   describe('tags="[1,2,3]"', () => {
     const InputTagComponentWithTags = new ClonedComponent({
-      data () { return { innerTags: ['Jerry', 'Kramer', 'Elaine'] } }
+      data () {
+        return { innerTags: ['Jerry', 'Kramer', 'Elaine'] }
+      }
     }).$mount()
 
     it('should load the tags', () => {
@@ -119,7 +131,9 @@ describe('InputTag.vue', () => {
 
     it('should have remove buttons', () => {
       renderer.renderToString(InputTagComponentWithTags, (err, str) => {
-        if (err) { throw err }
+        if (err) {
+          throw err
+        }
 
         const dom = new jsdom.JSDOM(str)
         const removeButtons = dom.window.document.querySelectorAll('a.remove')
@@ -251,21 +265,122 @@ describe('InputTag.vue', () => {
     })
   })
 
+  describe('do not allow duplicate tags by default', () => {
+    const InputTagISODateOnly = new ClonedComponent({
+      propsData: {}
+    }).$mount()
+
+    it('should only add unique tags', () => {
+      InputTagISODateOnly.newTag = 'foo'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = '123'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = 'mati@tucci.me'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = 'https://tucci.me'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = '123'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = 'mati@tucci.me'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = 'https://tucci.me'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = '2002-04-03'
+      InputTagISODateOnly.addNew()
+
+      expect(InputTagISODateOnly.innerTags.length).toEqual(5)
+    })
+  })
+
+  describe('allow duplicate tags if allowDuplicates prop is true', () => {
+    const InputTagISODateOnly = new ClonedComponent({
+      propsData: { allowDuplicates: true }
+    }).$mount()
+
+    it('should add all tags', () => {
+      InputTagISODateOnly.newTag = 'foo'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = '123'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = 'mati@tucci.me'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = 'https://tucci.me'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = '123'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = 'mati@tucci.me'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = 'https://tucci.me'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = '2002-04-03'
+      InputTagISODateOnly.addNew()
+
+      expect(InputTagISODateOnly.innerTags.length).toEqual(8)
+    })
+  })
+
+  describe('validate with function', () => {
+    const allowedTags = ['mati@tucci.me', 'https://tucci.me']
+    const validateFunction = tag => allowedTags.includes(tag)
+    const InputTagISODateOnly = new ClonedComponent({
+      propsData: { validate: validateFunction }
+    }).$mount()
+
+    it('should only add values validated with function', () => {
+      InputTagISODateOnly.newTag = 'foo'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = '123'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = 'mati@tucci.me'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = 'https://tucci.me'
+      InputTagISODateOnly.addNew()
+
+      InputTagISODateOnly.newTag = '2002-04-03'
+      InputTagISODateOnly.addNew()
+
+      expect(InputTagISODateOnly.innerTags.join()).toEqual(allowedTags.join())
+    })
+  })
+
   describe('CSS classes depending of input state', () => {
     it('should add activity class when input is focused', () => {
       InputTagComponent.$refs.inputtag.focus()
-      return Vue.nextTick()
-        .then(() => {
-          expect(InputTagComponent.$el.classList.contains('vue-input-tag-wrapper--active')).toBe(true)
-        })
+      return Vue.nextTick().then(() => {
+        expect(
+          InputTagComponent.$el.classList.contains(
+            'vue-input-tag-wrapper--active'
+          )
+        ).toBe(true)
+      })
     })
 
     it('should remove activity class when input is blurred', () => {
       InputTagComponent.$refs.inputtag.blur()
-      return Vue.nextTick()
-        .then(() => {
-          expect(InputTagComponent.$el.classList.contains('vue-input-tag-wrapper--active')).toBe(false)
-        })
+      return Vue.nextTick().then(() => {
+        expect(
+          InputTagComponent.$el.classList.contains(
+            'vue-input-tag-wrapper--active'
+          )
+        ).toBe(false)
+      })
     })
   })
 })


### PR DESCRIPTION
This is the best I can do. I don't get why some code does not reformat to your initial code.

I think using prettier can give more stable results. I can add it to work with eslint, if you want.

It must be I used prettier to get this result, but then I removed it from dependencies, but now eslint can't reformat it back.

This is instead of #70 