### PR TITLE
Fix issue where tab removes focus, and enter submits form.

### DIFF
--- a/src/components/InputTag.vue
+++ b/src/components/InputTag.vue
@@ -118,6 +118,8 @@ export default {
         this.innerTags.push(this.newTag);
         this.newTag = "";
         this.tagChange();
+
+        e.preventDefault()
       }
     },
 


### PR DESCRIPTION
This also fixes issues with other delimiters (like space, and comma) will keep the text in the input after expanding to a tag.