### PR TITLE
Add support for v-model.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,11 @@
 
 ## Installation
 
-#### NPM
+#### NPM / Yarn
 
 ```bash
 npm install vue-input-tag --save
 ```
-
-#### Yarn
 
 ```bash
 yarn add vue-input-tag

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install vue-input-tag --save
 yarn add vue-input-tag
 ```
 
-## Register the component
+Then you need to import and register it:
 
 ```js
 import InputTag from 'vue-input-tag'
@@ -34,6 +34,17 @@ import InputTag from 'vue-input-tag'
 ```js
 Vue.component('input-tag', InputTag)
 ```
+
+#### CDN
+
+```html
+<script src="https://unpkg.com/vue"></script>
+<script src="https://unpkg.com/vue-input-tag"></script>
+```
+
+Then you need to register it:
+
+`Vue.component('input-tag', vueInputTag.default)`
 
 ## Usage
 

--- a/src/components/InputTag.vue
+++ b/src/components/InputTag.vue
@@ -23,6 +23,10 @@ export default {
       type: Array,
       default: () => []
     },
+    value: {
+      type: Array,
+      default: () => []
+    },
     placeholder: {
       type: String,
       default: ""
@@ -62,7 +66,7 @@ export default {
   data() {
     return {
       newTag: "",
-      innerTags: [...this.tags],
+      innerTags: this.tags.concat(this.value),
       isInputActive: false
     };
   },
@@ -162,6 +166,7 @@ export default {
 
     tagChange() {
       this.$emit("update:tags", this.innerTags);
+      this.$emit("input", this.innerTags);
     }
   }
 };


### PR DESCRIPTION
This PR adds the ability to use `v-model` on the input-tag component.

```html
<input-tag v-model="tags"></input-tag>
```