### PR TITLE
Add some customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then you need to register it:
 ## Props
 | Name | Type | Default | Description |
 | ---:| --- | ---| --- |
-| tags | Array | [] | Tags to be render in the input |
+| value | Array | [] | Tags to be render in the input |
 | placeholder | String | "" | Placeholder to be shown when no tags |
 | read-only | Boolean | false | Set input to readonly |
 | add-tag-on-blur | Boolean | false | Add tag on input blur |

--- a/src/components/InputTag.vue
+++ b/src/components/InputTag.vue
@@ -73,6 +73,12 @@ export default {
     }
   },
 
+  watch: {
+    value() {
+      this.innerTags = [...this.value]
+    }
+  },
+
   methods: {
     focusNewTag() {
       if (this.readOnly || !this.$el.querySelector(".new-tag")) {

--- a/src/components/InputTag.vue
+++ b/src/components/InputTag.vue
@@ -175,7 +175,9 @@ export default {
   >
     <span v-for="(tag, index) in innerTags" :key="index" class="input-tag">
       <span>{{ tag }}</span>
-      <a v-if="!readOnly" @click.prevent.stop="remove(index)" class="remove"></a>
+      <a v-if="!readOnly" @click.prevent.stop="remove(index)" class="remove">
+        <slot name="remove-icon" />
+      </a>
     </span>
     <input
       v-if                     = "!readOnly && !isLimit"
@@ -229,7 +231,7 @@ export default {
   text-decoration: none;
 }
 
-.vue-input-tag-wrapper .input-tag .remove::before {
+.vue-input-tag-wrapper .input-tag .remove:empty::before {
   content: " x";
 }
 

--- a/src/components/InputTag.vue
+++ b/src/components/InputTag.vue
@@ -75,7 +75,7 @@ export default {
 
   watch: {
     value() {
-      this.innerTags = [...this.value]
+      this.innerTags = [...this.value];
     }
   },
 

--- a/tests/unit/InputTag.spec.js
+++ b/tests/unit/InputTag.spec.js
@@ -154,6 +154,19 @@ describe("InputTag.vue", () => {
       });
     });
 
+    describe("dynamic value", () => {
+      beforeEach(() => {
+        wrapper = shallowMount(InputTag, {
+          propsData: { value: [1, 2, 3] }
+        });
+      });
+
+      it("should watch value property changes", () => {
+        wrapper.setProps({ value: [1, 2, 3, 4] });
+        expect(wrapper.vm.innerTags.length).toEqual(4);
+      });
+    });
+
     describe("validate='text'", () => {
       beforeEach(() => {
         wrapper = shallowMount(InputTag, {

--- a/tests/unit/InputTag.spec.js
+++ b/tests/unit/InputTag.spec.js
@@ -302,4 +302,22 @@ describe("InputTag.vue", () => {
       ).toBeUndefined();
     });
   });
+
+  describe("slots", () => {
+    beforeEach(() => {
+      wrapper = shallowMount(InputTag, {
+        slots: {
+          "remove-icon": '<span class="close" />'
+        }
+      });
+
+      addTag(wrapper, "foo");
+    });
+
+    it("should render 'remove icon' slot as remove icon for a tag", () => {
+      expect(wrapper.find("a.remove").html()).toBe(
+        '<a class="remove"><span class="close"></span></a>'
+      );
+    });
+  });
 });


### PR DESCRIPTION
Using the vue-input-tag I have discovered some limitations. 
1) I am not able to dynamically pass a **value** property. I would like to pass initial tags to the input, but my data loads with some delay, so the input has already mounted and it's **innerTags** has already initialized. 
I added watch on **value** property to update **innerTags** according to passing value.
2) Default remove icon which is actually a 'x' symbol doesn't fit my design. I would like to override the remove icon. I added a named slot called "remove-icon" for be able to pass a custom remove icon. If slot is empty, then a default 'x' symbol will render.