### PR TITLE
Add trim option to input-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Then you need to register it:
 | ---:| --- | ---| --- |
 | value | Array | [] | Tags to be render in the input |
 | placeholder | String | "" | Placeholder to be shown when no tags |
+| trim | Boolean | false | Trims input tags from whitespaces |
 | read-only | Boolean | false | Set input to readonly |
 | add-tag-on-blur | Boolean | false | Add tag on input blur |
 | limit | String or Number | -1 (none) | Set a limit for the amount of tags |

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@ export default {
       readOnly: false,
       addTagOnBlur: false,
       allowDuplicates: false,
+      trim: false,
       placeholder: "Add Tag",
       tags: ["Jerry", "Kramer", "Elaine", "George"],
       limit: 10,
@@ -27,6 +28,7 @@ export default {
       html += this.placeholder ? ` placeholder="${this.placeholder}"` : "";
       html += ' v-model="tags"';
       html += this.readOnly ? ' :read-only="true"' : "";
+      html += this.trim ? ' trim' : "";
       html += this.addTagOnBlur ? ' :add-tag-on-blur="true"' : "";
       html += this.allowDuplicates ? ' :allow-duplicates="true"' : "";
       html += this.limit ? ' :limit="limit"' : "";
@@ -59,6 +61,10 @@ export default {
         <div class="form-group">
           <p class="label">readOnly:</p>
           <input v-model="readOnly" type="checkbox"/>
+        </div>
+        <div class="form-group">
+          <p class="label">trim:</p>
+          <input v-model="trim" type="checkbox"/>
         </div>
         <div class="form-group">
           <p class="label">addTagOnBlur:</p>
@@ -97,6 +103,7 @@ export default {
             :placeholder='placeholder'
             :read-only='readOnly'
             :validate='validate'
+            :trim="trim"
             :add-tag-on-blur='addTagOnBlur'
           />
 

--- a/src/components/InputTag.vue
+++ b/src/components/InputTag.vue
@@ -49,6 +49,10 @@ export default {
       type: Boolean,
       default: false
     },
+    trim: {
+      type: Boolean,
+      default: false
+    },
     limit: {
       type: Number,
       default: -1
@@ -110,12 +114,14 @@ export default {
         return;
       }
 
+      const tag = this.trim ? this.newTag.trim() : this.newTag;
+
       if (
-        this.newTag &&
-        (this.allowDuplicates || this.innerTags.indexOf(this.newTag) === -1) &&
-        this.validateIfNeeded(this.newTag)
+        tag &&
+        (this.allowDuplicates || this.innerTags.indexOf(tag) === -1) &&
+        this.validateIfNeeded(tag)
       ) {
-        this.innerTags.push(this.newTag);
+        this.innerTags.push(tag);
         this.newTag = "";
         this.tagChange();
 


### PR DESCRIPTION
Should close #98.

I've added the `trim` option to `InputTag` so it'd trim the new tags if set to true. I've changed the `addNew` method a little bit for that, but it shouldn't break anything that's already there.

I don't know the requirements for making a PR for this repo, so let me know if it can be improved.
