### PR TITLE
add async function support for `before-adding` and `validate` props

### DIFF
--- a/src/components/InputTag.vue
+++ b/src/components/InputTag.vue
@@ -99,7 +99,7 @@ export default {
       this.addNew(e);
     },
 
-    addNew(e) {
+    async addNew(e) {
       const keyShouldAddTag = e
         ? this.addTagOnKeys.indexOf(e.keyCode) !== -1
         : true;
@@ -114,13 +114,15 @@ export default {
       }
 
       const tag = this.beforeAdding
-        ? this.beforeAdding(this.newTag)
+        ? await this.beforeAdding(this.newTag)
         : this.newTag;
+
+        const valid = await this.validateIfNeeded(tag);
 
       if (
         tag &&
         (this.allowDuplicates || this.innerTags.indexOf(tag) === -1) &&
-        this.validateIfNeeded(tag)
+        valid
       ) {
         this.innerTags.push(tag);
         this.newTag = "";

--- a/tests/unit/InputTag.spec.js
+++ b/tests/unit/InputTag.spec.js
@@ -1,11 +1,11 @@
 import { shallowMount } from "@vue/test-utils";
 import InputTag from "@/components/InputTag.vue";
 
-function addTag(wrapper, newTag) {
+async function addTag(wrapper, newTag) {
   // TODO: use wrapper.trigger('keydown', { which: 65 })
   // so we have an event on the vm.addNew method
   wrapper.setData({ newTag });
-  wrapper.vm.addNew();
+  await wrapper.vm.addNew();
 }
 
 describe("InputTag.vue", () => {
@@ -21,10 +21,10 @@ describe("InputTag.vue", () => {
   });
 
   describe("addNew()", () => {
-    beforeEach(() => {
-      addTag(wrapper, "tag 1");
-      addTag(wrapper, "tag 1");
-      addTag(wrapper, "tag 2");
+    beforeEach(async () => {
+      await addTag(wrapper, "tag 1");
+      await addTag(wrapper, "tag 1");
+      await addTag(wrapper, "tag 2");
     });
 
     it("should have 2 tags", () => {
@@ -57,10 +57,10 @@ describe("InputTag.vue", () => {
   });
 
   describe("remove(index)", () => {
-    beforeEach(() => {
-      addTag(wrapper, "tag 1");
-      addTag(wrapper, "tag 2");
-      addTag(wrapper, "tag 3");
+    beforeEach(async () => {
+      await addTag(wrapper, "tag 1");
+      await addTag(wrapper, "tag 2");
+      await addTag(wrapper, "tag 3");
 
       wrapper.vm.remove(1);
     });
@@ -79,12 +79,13 @@ describe("InputTag.vue", () => {
   });
 
   describe("removeLastTag()", () => {
-    beforeEach(() => {
-      addTag(wrapper, "tag 1");
-      addTag(wrapper, "tag 2");
-      addTag(wrapper, "tag 3");
+    beforeEach(async () => {
+      await addTag(wrapper, "tag 1");
+      await addTag(wrapper, "tag 2");
+      await addTag(wrapper, "tag 3");
 
       wrapper.vm.removeLastTag();
+      console.log(wrapper.vm.innerTags);
     });
 
     it("should have 2 tags", () => {


### PR DESCRIPTION
I need the value to be validated by the server side before added to `innerTags` when user hit Enter, so the validate and before-adding function should return a promise, for example:

```
    validate(val) {
      return new Promise((resolve, reject) => {

        this.dataAuthorityService.getAuthorityFromAccount(val).then(res => {
          if (res.data.length > 0) {
            resolve(res.data.id)
          }
          else {
            alert('failed')
          }
        }).catch(error => {
           alert('failed')
        })

      })
```