### PR TITLE
Add available events to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ Then you need to register it:
 | add-tag-on-keys | Array | [ 13 (return), 188 (comma), 9 (tab) ] | Keys that are going to add the new tag
 | allow-duplicates | Boolean | false | Allow duplicate tags
 | before-adding | Function | null | Function (allows async) to normalize tag before adding. E.g `(tag) => tag.toUpperCase()`
+
+## Events
+| Name | Arguments | Description |
+| ---: | --- | --- |
+| input | Array with tags | Emitted when a tag is added (after successful validation) and when a tag is removed |
+| update:tags | Array with tags | Same as input event |


### PR DESCRIPTION
This component emits two events, input and update:tags which are fired when tags are added and removed.
This was missing from the README.