### PR TITLE
Add maxlength prop for input

### DIFF
--- a/src/components/InputTag.vue
+++ b/src/components/InputTag.vue
@@ -59,6 +59,10 @@ export default {
     },
     beforeAdding: {
       type: Function
+    },
+    maxlength: {
+      type: Number,
+      default: Number.MAX_SAFE_INTEGER
     }
   },
 
@@ -198,6 +202,7 @@ export default {
       v-if="!readOnly && !isLimit"
       ref="inputtag"
       :placeholder="placeholder"
+      :maxlength="maxlength"
       type="text"
       v-model="newTag"
       v-on:keydown.delete.stop="removeLastTag"


### PR DESCRIPTION
In react-tagsinput you can limit text input length.
The vue-input-tag has no input length limit, so it is entered infinitely.
Please fix this problem.